### PR TITLE
Clarify that all inputs are valid

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -202,6 +202,8 @@ In the examples, the `→` character is used to represent tabs.
 
 ## Characters and lines
 
+All inputs are valid CommonMark.
+
 The input is a sequence of zero or more [lines](#line).
 
 A [line](@line)


### PR DESCRIPTION
With reference to [this Discourse thread](http://talk.commonmark.org/t/specify-when-if-ever-parsers-should-give-up/969):

This makes it explicitly obvious that any input is valid CommonMark and is
expected to be parsed.  The spec didn't previously take an explicit
stance on this, but it could be pieced together by a careful reader. Reference parsers conform to this.

It's a strong assertion and useful to have in mind when reading about
the details of the format.  Readers are likely to be familiar with
more restrictive markup formats (like HTML) which parsers _can_ fail to
parse, so it's good to make this obvious from the start.