### PR TITLE
Dead code: Remove line assigning to Parser's _lastLineBlank property

### DIFF
--- a/js/lib/blocks.js
+++ b/js/lib/blocks.js
@@ -489,7 +489,6 @@ var incorporateLine = function(ln) {
         this.tip._strings.length > 0) {
         // lazy paragraph continuation
 
-        this._lastLineBlank = false;
         this.addLine(ln, offset);
 
     } else { // not a lazy continuation


### PR DESCRIPTION
It looks like the line is unused (the property is on Node objects).