### PR TITLE
Remove unnecessary return of value

### DIFF
--- a/js/lib/blocks.js
+++ b/js/lib/blocks.js
@@ -556,7 +556,7 @@ var finalize = function(block, lineNumber) {
     var above = block._parent || this.top;
     // don't do anything if the block is already closed
     if (!block._open) {
-        return 0;
+        return;
     }
     block._open = false;
     block.sourcepos[1] = [lineNumber, this.lastLineLength + 1];


### PR DESCRIPTION
In other cases, there is no return, and no caller checks for a return
value.