### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(SRCDIR)/case_fold_switch.inc: $(DATADIR)/CaseFolding-3.2.0.txt
 $(SRCDIR)/scanners.c: $(SRCDIR)/scanners.re
 	re2c --case-insensitive -b -i --no-generation-date -o $@ $<
 
-test: $(SPEC) $(BUILDDIR)
+test: $(SPEC) cmake_build
 	make -C $(BUILDDIR) test || (cat $(BUILDDIR)/Testing/Temporary/LastTest.log && exit 1)
 
 $(ALLTESTS): spec.txt

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ cmake_build: $(BUILDDIR)
 	@make -j2 -C $(BUILDDIR)
 	@echo "Binaries can be found in $(BUILDDIR)/src"
 
-$(BUILDDIR): $(SRCDIR)/html_unescape.h $(SRCDIR)/case_fold_switch.inc
+$(BUILDDIR):
 	@cmake --version > /dev/null || (echo "You need cmake to build this program: http://www.cmake.org/download/" && exit 1)
 	mkdir -p $(BUILDDIR); \
 	cd $(BUILDDIR); \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SRCDIR?=src
-DATADIR?=data
+SRCDIR=src
+DATADIR=data
 BUILDDIR?=build
 GENERATOR?=Unix Makefiles
 MINGW_BUILDDIR?=build-mingw
@@ -13,7 +13,7 @@ BENCHDIR=bench
 BENCHFILE=$(BENCHDIR)/benchinput.md
 ALLTESTS=alltests.md
 NUMRUNS?=10
-PROG?=$(BUILDDIR)/src/cmark
+PROG=$(BUILDDIR)/src/cmark
 BENCHINP?=README.md
 JSMODULES=$(wildcard js/lib/*.js)
 VERSION?=$(SPECVERSION)

--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,18 @@ JSMODULES=$(wildcard js/lib/*.js)
 VERSION?=$(SPECVERSION)
 RELEASE?=CommonMark-$(VERSION)
 
-.PHONY: all spec leakcheck clean fuzztest dingus upload jshint test testjs benchjs update-site upload-site check npm debug mingw archive tarball ziparchive testtarball testziparchive testlib bench astyle
+.PHONY: all cmake_build spec leakcheck clean fuzztest dingus upload jshint test testjs benchjs update-site upload-site npm debug mingw archive tarball ziparchive testtarball testziparchive testlib bench astyle
 
-all: $(PROG) man/man3/cmark.3
+all: cmake_build man/man3/cmark.3
 	@echo "Binaries can be found in $(BUILDDIR)/src"
 
-$(PROG): $(BUILDDIR)
+$(PROG): cmake_build
+
+cmake_build: $(BUILDDIR)
 	@make -j2 -C $(BUILDDIR)
 
-check:
+$(BUILDDIR): $(SRCDIR)/html_unescape.h $(SRCDIR)/case_fold_switch.inc
 	@cmake --version > /dev/null || (echo "You need cmake to build this program: http://www.cmake.org/download/" && exit 1)
-
-$(BUILDDIR): check $(SRCDIR)/html_unescape.h $(SRCDIR)/case_fold_switch.inc
 	mkdir -p $(BUILDDIR); \
 	cd $(BUILDDIR); \
 	cmake .. -G "$(GENERATOR)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ BENCHINP?=README.md
 JSMODULES=$(wildcard js/lib/*.js)
 VERSION?=$(SPECVERSION)
 RELEASE?=CommonMark-$(VERSION)
+INSTALL_PREFIX?=/usr/local
 
 .PHONY: all cmake_build spec leakcheck clean fuzztest dingus upload jshint test testjs benchjs update-site upload-site npm debug mingw archive tarball ziparchive testtarball testziparchive testlib bench astyle
 
@@ -33,7 +34,10 @@ $(BUILDDIR): $(SRCDIR)/html_unescape.h $(SRCDIR)/case_fold_switch.inc
 	@cmake --version > /dev/null || (echo "You need cmake to build this program: http://www.cmake.org/download/" && exit 1)
 	mkdir -p $(BUILDDIR); \
 	cd $(BUILDDIR); \
-	cmake .. -G "$(GENERATOR)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+	cmake .. \
+		-G "$(GENERATOR)" \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX)
 
 install: $(BUILDDIR)
 	make -C $(BUILDDIR) install

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ RELEASE?=CommonMark-$(VERSION)
 .PHONY: all cmake_build spec leakcheck clean fuzztest dingus upload jshint test testjs benchjs update-site upload-site npm debug mingw archive tarball ziparchive testtarball testziparchive testlib bench astyle
 
 all: cmake_build man/man3/cmark.3
-	@echo "Binaries can be found in $(BUILDDIR)/src"
 
 $(PROG): cmake_build
 
 cmake_build: $(BUILDDIR)
 	@make -j2 -C $(BUILDDIR)
+	@echo "Binaries can be found in $(BUILDDIR)/src"
 
 $(BUILDDIR): $(SRCDIR)/html_unescape.h $(SRCDIR)/case_fold_switch.inc
 	@cmake --version > /dev/null || (echo "You need cmake to build this program: http://www.cmake.org/download/" && exit 1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ the repository to reduce build dependencies.
 If you have GNU make, you can simply `make`, `make test`, and `make
 install`.  This calls [cmake] to create a `Makefile` in the `build`
 directory, then uses that `Makefile` to create the executable and
-library.  The binaries can be found in `build/src`.
+library.  The binaries can be found in `build/src`.  The default
+installation prefix is `/usr/local`.  To change the installation
+prefix, pass the `INSTALL_PREFIX` variable if you run `make` for the
+first time: `make INSTALL_PREFIX=path`.
 
 For a more portable method, you can use [cmake] manually. [cmake] knows
 how to create build environments for many build systems.  For example,


### PR DESCRIPTION
This pull request improves the build process in several ways:

- `cmake` is only run once when `make` is invoked for the first time.
  Subsequent calls to `make` don't reconfigure the project.
- `make INSTALL_PREFIX=path` can be used to specify the install prefix.
- `make test` automatically (re)builds the project before running tests.