### PR TITLE
mistake in examples of left/right flanking delims

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -4611,14 +4611,14 @@ Here are some examples of delimiter runs.
      _"abc"
     ```
 
-  - Both right and right-flanking:
+  - Both left and right-flanking:
 
     ```
     abc***def
     "abc"_"def"
     ```
 
-  - Neither right nor right-flanking:
+  - Neither left nor right-flanking:
 
     ```
     abc *** def


### PR DESCRIPTION
Please see the diff. It clearly looks as a mistake to me.