### PR TITLE
Fix license image

### DIFF
--- a/tools/template.html
+++ b/tools/template.html
@@ -93,7 +93,7 @@ $$(document).ready(function() {
 <a rel="license"
    href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative
    Commons BY-SA" style="border-width:0"
-   src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"
+   src="https://licensebuttons.net/l/by-sa/4.0/80x15.png"
    /></a><br/><span style="display:none"><span xmlns:dct="http://purl.org/dc/terms/"
    href="http://purl.org/dc/dcmitype/Text" property="dct:title"
    rel="dct:type">CommonMark Spec</span> by


### PR DESCRIPTION
The license image was broken, it appears that it redirects to licensebuttons.net now:

```
curl -i https://i.creativecommons.org/l/by-sa/4.0/80x15.png
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 31 Mar 2015 17:29:53 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://licensebuttons.net/l/by-sa/4.0/80x15.png
```