### PR TITLE
Specify nested link definition behavior in prose

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5818,7 +5818,9 @@ A [link text](@link-text) consists of a sequence of zero or more
 inline elements enclosed by square brackets (`[` and `]`).  The
 following rules apply:
 
-- Links may not contain other links, at any level of nesting.
+- Links may not contain other links, at any level of nesting. If
+  multiple otherwise valid link definitions appear nested inside each
+  other, the inner-most definition is used.
 
 - Brackets are allowed in the [link text] only if (a) they
   are backslash-escaped or (b) they appear as a matched pair of brackets,


### PR DESCRIPTION
The behavior was already specified in examples 426, 427, 428, 440, 441; this change merely describes it in the textual part.

I am not set on this particular phrasing; feel free to decline this PR and phrase it differently. I just stumbled over this and feel it should be spelled out in writing.