### PR TITLE
add /spec.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.bak
+/spec.html


### PR DESCRIPTION
just ignore /spec.html (generated by `python3 tools/makespec.py html > spec.html`)
