### PR TITLE
add spec examples showing the use of fragment identifiers in links

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -6031,6 +6031,23 @@ in Markdown:
 <p><a href="foo):">link</a></p>
 .
 
+A link can start with a fragment identifier:
+
+.
+[link](#fragment)
+.
+<p><a href="#fragment">link</a></p>
+.
+
+
+A link can start also contain a a fragment identifier:
+
+.
+[link](http://example.com#fragment)
+.
+<p><a href="http://example.com#fragment">link</a></p>
+.
+
 Note that a backslash before a non-escapable character is
 just a backslash:
 


### PR DESCRIPTION
Consider adding these (or similar) examples showing the use of fragment identifiers in links.  These examples can help implementors avoid errors special characters in links.