### PR TITLE
Don't list "title" twice as HTML block tag

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1652,7 +1652,7 @@ followed by one of the strings (case-insensitive) `address`,
 `footer`, `form`, `frame`, `frameset`, `h1`, `head`, `header`, `hr`,
 `html`, `legend`, `li`, `link`, `main`, `menu`, `menuitem`, `meta`,
 `nav`, `noframes`, `ol`, `optgroup`, `option`, `p`, `param`, `pre`,
-`section`, `source`, `title`, `summary`, `table`, `tbody`, `td`,
+`section`, `source`, `summary`, `table`, `tbody`, `td`,
 `tfoot`, `th`, `thead`, `title`, `tr`, `track`, `ul`, followed
 by [whitespace], the end of the line, the string `>`, or
 the string `/>`.\


### PR DESCRIPTION
It's already listed in alphabetical order on the next line.