### PR TITLE
Add an example with mixed indentation code block in "Tabs" section

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -304,6 +304,15 @@ by spaces with a tab stop of 4 characters.
 </blockquote>
 .
 
+.
+    foo
+→bar
+.
+<pre><code>foo
+bar
+</code></pre>
+.
+
 
 ## Insecure characters
 


### PR DESCRIPTION
This makes sure that implementations skip columns instead of offsets for
continued indented code blocks.

Background: I was implementing the new tab logic and was surprised that
all the spec tests passed even though I hadn't changed the continuation
logic of indented code blocks to skip columns. The added example checks
this.