### PR TITLE
Add test case for nested lists with an indent > 4

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -4439,13 +4439,18 @@ So, in this case we need two spaces indent:
 - foo
   - bar
     - baz
+      - boo
 .
 <ul>
 <li>foo
 <ul>
 <li>bar
 <ul>
-<li>baz</li>
+<li>baz
+<ul>
+<li>boo</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -4460,11 +4465,13 @@ One is not enough:
 - foo
  - bar
   - baz
+   - boo
 .
 <ul>
 <li>foo</li>
 <li>bar</li>
 <li>baz</li>
+<li>boo</li>
 </ul>
 ````````````````````````````````
 


### PR DESCRIPTION
Hi jgm,
This is a PR to slightly change an existing test for nested list items to add another level which has an indent > 4 chars, as I came across a bug in Markdig, and the specs didn't trigger this one.

