### PR TITLE
Switch less-than to less-than-or-equal-to for clarity

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -3628,7 +3628,7 @@ The following rules define [list items]:
 1.  **Basic case.**  If a sequence of lines *Ls* constitute a sequence of
     blocks *Bs* starting with a [non-whitespace character] and not separated
     from each other by more than one blank line, and *M* is a list
-    marker of width *W* followed by 0 < *N* < 5 spaces, then the result
+    marker of width *W* followed by 1 ≤ *N* ≤ 4 spaces, then the result
     of prepending *M* and the following spaces to the first line of
     *Ls*, and indenting subsequent lines of *Ls* by *W + N* spaces, is a
     list item with *Bs* as its contents.  The type of the list item


### PR DESCRIPTION
In a list item, in the [basic case](http://spec.commonmark.org/0.25/#list-items), the marker is followed by either 1, 2, 3, or 4 spaces. I think it is more clear to write that there are 1-4 spaces, instead of "more than 0 but less than 5".

* Initial indent is consistently referred to as "0-3 spaces."
* I accidentally thought 0 to 5 spaces was allowed, skimming the definition.
* Using 0 and 5 are not important to the basic case. They just happen to be the integers just outside the range of 1-4, which are the important numbers.