### PR TITLE
Added drafts to publish spec in npm, #394

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+
+exports.text = fs.readFileSync(path.join(__dirname, 'spec.txt'), 'utf8');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "commonmark-spec",
+  "version": "-",
+  "description": "Commonmark spec.",
+  "keywords": [
+    "commonmark",
+    "markdown"
+  ],
+  "repository": "jgm/CommonMark",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "spec.txt"
+  ]
+}


### PR DESCRIPTION
__package.json__

- File is correct, but you probably wish to update some fields.
- `version` field should be updated by scripts as part of publish process.

__index.js__

- now has only `require('commonmark-spec').text`
- if someone needs json/xml formats, those can be added later as `require('commonmark-spec').json` etc.

Quick check from CLI:

```bash
node -e "console.log(require('./').text)"
```

If you don't like to merge this intermediate results - feel free to use it as you wish.