### PR TITLE
Example for disabling image markup: remove a backslash

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -8319,11 +8319,11 @@ The link labels are case-insensitive:
 ````````````````````````````````
 
 
-If you just want bracketed text, you can backslash-escape the
-opening `!` and `[`:
+If you just want a literal `!` followed by bracketed text, you can
+backslash-escape the opening `[`:
 
 ```````````````````````````````` example
-\!\[foo]
+!\[foo]
 
 [foo]: /url "title"
 .


### PR DESCRIPTION
Escaping `[` disables the markup, escaping `!` on top of that doesn't change anything and is therefore misleading in this example.