### PR TITLE
Add fenced code block example with not enough backticks.

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1645,6 +1645,15 @@ With tildes:
 </code></pre>
 ````````````````````````````````
 
+Fewer than three backticks is not enough:
+
+```````````````````````````````` example
+``
+foo
+``
+.
+<p><code>foo</code></p>
+````````````````````````````````
 
 The closing code fence must use the same character as the opening
 fence:


### PR DESCRIPTION
This is covered by example 60 (and probably others) as well, but it would be nice to have an example for it in the fenced code block section.