### PR TITLE
Remove "code" from examples for blocks containing inlines

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -483,7 +483,7 @@ We can think of a document as a sequence of
 quotations, lists, headings, rules, and code blocks.  Some blocks (like
 block quotes and list items) contain other blocks; others (like
 headings and paragraphs) contain [inline](@) content---text,
-links, emphasized text, images, code, and so on.
+links, emphasized text, images, and so on.
 
 ## Precedence
 


### PR DESCRIPTION
Code blocks don't have inline content, right?

AFAIU they have a third type of content, but that's probably not worth mentioning (and coming up with a name for).