### PR TITLE
Clarify precedence of thematic break

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -3639,11 +3639,14 @@ The following rules define [list items]:
     If the list item is ordered, then it is also assigned a start
     number, based on the ordered list marker.
 
-    Exceptions: When the first list item in a [list] interrupts
-    a paragraph---that is, when it starts on a line that would
-    otherwise count as [paragraph continuation text]---then (a)
-    the lines *Ls* must not begin with a blank line, and (b) if
-    the list item is ordered, the start number must be 1.
+    Exceptions:
+    1. When the first list item in a [list] interrupts
+       a paragraph---that is, when it starts on a line that would
+       otherwise count as [paragraph continuation text]---then (a)
+       the lines *Ls* must not begin with a blank line, and (b) if
+       the list item is ordered, the start number must be 1.
+    2. If any line is a [thematic break][thematic breaks] then
+       that line is not a list item.
 
 For example, let *Ls* be the lines
 

--- a/spec.txt
+++ b/spec.txt
@@ -3640,6 +3640,7 @@ The following rules define [list items]:
     number, based on the ordered list marker.
 
     Exceptions:
+    
     1. When the first list item in a [list] interrupts
        a paragraph---that is, when it starts on a line that would
        otherwise count as [paragraph continuation text]---then (a)


### PR DESCRIPTION
There already exists the statement: "When both a thematic break and a list item are possible
interpretations of a line, the thematic break takes precedence".

This adjustment ensures that this precedence is achieved by the list item definition.