### PR TITLE
Mention removing surrounding whitespace from link labels

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -7568,7 +7568,8 @@ characters inside the square brackets.
 
 One label [matches](@)
 another just in case their normalized forms are equal.  To normalize a
-label, perform the *Unicode case fold* and collapse consecutive internal
+label, perform the *Unicode case fold*, strip leading and trailing
+[whitespace] and collapse consecutive internal
 [whitespace] to a single space.  If there are multiple
 matching reference link definitions, the one that comes first in the
 document is used.  (It is desirable in such cases to emit a warning.)


### PR DESCRIPTION
According to the JS reference implementation, these are matching link labels, although one is surrounded by spaces:

```
[ a ]: b

[a]
```

---

On a related note: It is not quite clear if the brackets themselves are part of the *link label* or not.

> A [link label](http://spec.commonmark.org/0.27/#link-label) begins with a left bracket (`[`) and ends with the first right bracket (`]`) that is not backslash-escaped.

The words "begin" and "end" sound like the brackets are included.
However, that can't be, because it's not allowed:

> Unescaped square bracket characters are not allowed in link labels.

*If* the brackets are part of the link label, the word *internal* whitespace doesn't quite mean what it's supposed to mean.

My English-fu isn't good enough to suggest an improvement in wording.