### PR TITLE
Allow shortcut reference link before unmatched label

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -7953,7 +7953,8 @@ allowed between the two sets of brackets:
 A [shortcut reference link](@)
 consists of a [link label] that [matches] a
 [link reference definition] elsewhere in the
-document and is not followed by `[]` or a link label.
+document and is not followed by `[]` or a [link label] that
+[matches] a [link reference definition].
 The contents of the first link label are parsed as inlines,
 which are used as the link's text.  The link's URI and title
 are provided by the matching link reference definition.
@@ -8104,8 +8105,8 @@ Here, though, `[foo][bar]` is parsed as a reference, since
 ````````````````````````````````
 
 
-Here `[foo]` is not parsed as a shortcut reference, because it
-is followed by a link label (even though `[bar]` is not defined):
+Here `[foo]` is parsed as a shortcut reference, although it
+is followed by a link label (but the label `[bar]` is not defined):
 
 ```````````````````````````````` example
 [foo][bar][baz]
@@ -8113,7 +8114,7 @@ is followed by a link label (even though `[bar]` is not defined):
 [baz]: /url1
 [foo]: /url2
 .
-<p>[foo]<a href="/url1">bar</a></p>
+<p><a href="/url2">foo</a><a href="/url1">bar</a></p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
This is of course an edge case. I still think the spec should be changed to be more consistent.

This concerns [example 540 from the spec 0.27](http://spec.commonmark.org/0.27/#example-540):

```
[foo][bar][baz]

[baz]: /url1
[foo]: /url2
```

Everywhere else, reference links are only recognized if they are *matching*. Unmatched reference links don't have any significance to the parser.

Therefore, in this case, the unmatched reference link `[foo][bar]` should also not have any significance, and the parser should continue to happily match `[foo]` as *shortcut reference link*.